### PR TITLE
Add Ignition Gazebo switches to ROS2 control sim config

### DIFF
--- a/robotiq_description/urdf/robotiq_sim_gripper.ros2_control.xacro
+++ b/robotiq_description/urdf/robotiq_sim_gripper.ros2_control.xacro
@@ -3,6 +3,7 @@
 
     <xacro:macro name="robotiq_sim_gripper_ros2_control" params="
       name
+      sim_ignition:=false
       sim_isaac:=false
       use_fake_hardware:=false">
 
@@ -14,13 +15,25 @@
                     <param name="joint_states_topic">/isaac_joint_states</param>
                 </xacro:if>
                 <xacro:if value="${use_fake_hardware}">
-                    <plugin>mock_components/GenericSystem</plugin>
+                    <xacro:if value="${sim_ignition}">
+                        <plugin>ign_ros2_control/IgnitionSystem</plugin>
+                    </xacro:if>
+                    <xacro:unless value="${sim_ignition}">
+                        <plugin>mock_components/GenericSystem</plugin>
+                    </xacro:unless>
                     <param name="fake_sensor_commands">${fake_sensor_commands}</param>
                     <param name="state_following_offset">0.0</param>
                 </xacro:if>
             </hardware>
             <joint name="robotiq_85_left_knuckle_joint">
-                <param name="initial_position">0.7929</param>
+                <!-- With Ignition, we have mimic joints, so we only need this command interface activated -->
+                <xacro:if value="${sim_ignition}">
+                    <param name="initial_position">0.2</param>
+                </xacro:if>
+                <xacro:unless value="${sim_ignition}">
+                    <param name="initial_position">0.7929</param>
+                </xacro:unless>
+
                 <command_interface name="position" />
                 <state_interface name="position"/>
                 <state_interface name="velocity"/>
@@ -28,42 +41,55 @@
             <joint name="robotiq_85_right_knuckle_joint">
                 <param name="mimic">robotiq_85_left_knuckle_joint</param>
                 <param name="multiplier">-1</param>
-                <command_interface name="position"/>
-                <state_interface name="position"/>
-                <state_interface name="velocity"/>
+                <xacro:unless value="${sim_ignition}">
+                    <command_interface name="position"/>
+                    <state_interface name="position"/>
+                    <state_interface name="velocity"/>
+                </xacro:unless>
             </joint>
             <joint name="robotiq_85_left_inner_knuckle_joint">
                 <param name="mimic">robotiq_85_left_knuckle_joint</param>
                 <param name="multiplier">1</param>
-                <command_interface name="position" />
-                <state_interface name="position" />
-                <state_interface name="velocity" />
+                <xacro:unless value="${sim_ignition}">
+                    <command_interface name="position"/>
+                    <state_interface name="position"/>
+                    <state_interface name="velocity"/>
+                </xacro:unless>
             </joint>
             <joint name="robotiq_85_right_inner_knuckle_joint">
                 <param name="mimic">robotiq_85_left_knuckle_joint</param>
                 <param name="multiplier">-1</param>
-                <command_interface name="position" />
-                <state_interface name="position" />
-                <state_interface name="velocity" />
+                <xacro:unless value="${sim_ignition}">
+                    <command_interface name="position"/>
+                    <state_interface name="position"/>
+                    <state_interface name="velocity"/>
+                </xacro:unless>
             </joint>
             <joint name="robotiq_85_left_finger_tip_joint">
                 <param name="mimic">robotiq_85_left_knuckle_joint</param>
                 <param name="multiplier">-1</param>
-                <command_interface name="position" />
-                <state_interface name="position" />
-                <state_interface name="velocity" />
+                <xacro:unless value="${sim_ignition}">
+                    <command_interface name="position"/>
+                    <state_interface name="position"/>
+                    <state_interface name="velocity"/>
+                </xacro:unless>
             </joint>
             <joint name="robotiq_85_right_finger_tip_joint">
                 <param name="mimic">robotiq_85_left_knuckle_joint</param>
                 <param name="multiplier">1</param>
-                <command_interface name="position" />
-                <state_interface name="position" />
-                <state_interface name="velocity" />
+                <xacro:unless value="${sim_ignition}">
+                    <command_interface name="position"/>
+                    <state_interface name="position"/>
+                    <state_interface name="velocity"/>
+                </xacro:unless>
             </joint>
-            <gpio name="reactivate_gripper">
-                <command_interface name="reactivate_gripper_cmd" />
-                <command_interface name="reactivate_gripper_response" />
-            </gpio>
+            <!-- Not active for Ignition -->
+            <xacro:unless value="${sim_ignition}">
+                <gpio name="reactivate_gripper">
+                    <command_interface name="reactivate_gripper_cmd" />
+                    <command_interface name="reactivate_gripper_response" />
+                </gpio>
+            </xacro:unless>
         </ros2_control>
     </xacro:macro>
 


### PR DESCRIPTION
This is a slightly modified version of https://github.com/livanov93/ros2_robotiq_gripper/tree/sim which has the option of being configured for Ignition, rather than just making the changes.

The goal is to use this in MoveIt Studio in a way that works for both Isaac Sim and Ignition Gazebo as simulator options.