### PR TITLE
Fix Transitive Includes and Linking for Atomic when Building with Clang

### DIFF
--- a/robotiq_driver/CMakeLists.txt
+++ b/robotiq_driver/CMakeLists.txt
@@ -36,6 +36,7 @@ target_include_directories(
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
 )
+target_link_libraries(${PROJECT_NAME} atomic)
 ament_target_dependencies(
   ${PROJECT_NAME}
   ${THIS_PACKAGE_INCLUDE_DEPENDS}

--- a/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -28,6 +28,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>


### PR DESCRIPTION
When compiling with clang + stdc++ we get the follow error,

```
Starting >>> robotiq_driver
--- stderr: robotiq_driver                              
librobotiq_driver.so: error: undefined reference to '__atomic_load'
librobotiq_driver.so: error: undefined reference to '__atomic_store'
clang: error: linker command failed with exit code 1 (use -v to see invocation)
gmake[2]: *** [CMakeFiles/gripper_interface_test.dir/build.make:292: gripper_interface_test] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:165: CMakeFiles/gripper_interface_test.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
```

This change fixes it by linking against the library and including the header where it's used.