### PR TITLE
Add ros2_control switch and enable mesh loadingin Gazebo

### DIFF
--- a/robotiq_description/urdf/robotiq_gripper_macro.urdf.xacro
+++ b/robotiq_description/urdf/robotiq_gripper_macro.urdf.xacro
@@ -28,12 +28,12 @@
         <link name="${prefix}robotiq_85_base_link">
             <visual>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/visual/robotiq_base.dae" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/visual/robotiq_base.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/collision/robotiq_base.stl" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/collision/robotiq_base.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -46,12 +46,12 @@
         <link name="${prefix}robotiq_85_left_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/visual/left_knuckle.dae" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/visual/left_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/collision/left_knuckle.stl" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/collision/left_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -64,12 +64,12 @@
         <link name="${prefix}robotiq_85_right_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/visual/right_knuckle.dae" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/visual/right_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/collision/right_knuckle.stl" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/collision/right_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -82,12 +82,12 @@
         <link name="${prefix}robotiq_85_left_finger_link">
             <visual>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/visual/left_finger.dae" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/visual/left_finger.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/collision/left_finger.stl" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/collision/left_finger.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -100,12 +100,12 @@
         <link name="${prefix}robotiq_85_right_finger_link">
             <visual>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/visual/right_finger.dae" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/visual/right_finger.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/collision/right_finger.stl" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/collision/right_finger.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -118,12 +118,12 @@
         <link name="${prefix}robotiq_85_left_inner_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/visual/left_inner_knuckle.dae" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/visual/left_inner_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/collision/left_inner_knuckle.stl" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/collision/left_inner_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -136,12 +136,12 @@
         <link name="${prefix}robotiq_85_right_inner_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/visual/right_inner_knuckle.dae" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/visual/right_inner_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/collision/right_inner_knuckle.stl" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/collision/right_inner_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -154,12 +154,12 @@
         <link name="${prefix}robotiq_85_left_finger_tip_link">
             <visual>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/visual/left_finger_tip.dae" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/visual/left_finger_tip.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/collision/left_finger_tip.stl" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/collision/left_finger_tip.stl" />
                 </geometry>
                 <surface>
                     <friction>
@@ -190,12 +190,12 @@
         <link name="${prefix}robotiq_85_right_finger_tip_link">
             <visual>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/visual/right_finger_tip.dae" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/visual/right_finger_tip.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="$(find robotiq_description)/meshes/collision/right_finger_tip.stl" />
+                    <mesh filename="file://$(find robotiq_description)/meshes/collision/right_finger_tip.stl" />
                 </geometry>
                 <surface>
                     <friction>

--- a/robotiq_description/urdf/robotiq_gripper_macro.urdf.xacro
+++ b/robotiq_description/urdf/robotiq_gripper_macro.urdf.xacro
@@ -9,29 +9,31 @@
         sim_isaac:=false
         use_fake_hardware:=false
         fake_sensor_commands:=false
+        include_ros2_control:=true
         com_port:=/dev/ttyUSB0">
 
         <!-- ros2 control include -->
         <xacro:include filename="$(find robotiq_description)/urdf/robotiq_gripper.ros2_control.xacro" />
-        <!-- ros2 control instance -->
-        <xacro:robotiq_gripper_ros2_control
-            name="${name}" prefix="${prefix}"
-            sim_ignition="${sim_ignition}"
-            sim_isaac="${sim_isaac}"
-            use_fake_hardware="${use_fake_hardware}"
-            fake_sensor_commands="${fake_sensor_commands}"
-            com_port="${com_port}"
-            />
+        <!-- if we are simulating or directly communicating with the gripper we need a ros2 control instance -->
+        <xacro:if value="${include_ros2_control}">
+            <xacro:robotiq_gripper_ros2_control
+                name="${name}" prefix="${prefix}"
+                sim_ignition="${sim_ignition}"
+                sim_isaac="${sim_isaac}"
+                use_fake_hardware="${use_fake_hardware}"
+                fake_sensor_commands="${fake_sensor_commands}"
+                com_port="${com_port}"/>
+        </xacro:if>
 
         <link name="${prefix}robotiq_85_base_link">
             <visual>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/visual/robotiq_base.dae" />
+                    <mesh filename="$(find robotiq_description)/meshes/visual/robotiq_base.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/collision/robotiq_base.stl" />
+                    <mesh filename="$(find robotiq_description)/meshes/collision/robotiq_base.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -44,12 +46,12 @@
         <link name="${prefix}robotiq_85_left_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/visual/left_knuckle.dae" />
+                    <mesh filename="$(find robotiq_description)/meshes/visual/left_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/collision/left_knuckle.stl" />
+                    <mesh filename="$(find robotiq_description)/meshes/collision/left_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -62,12 +64,12 @@
         <link name="${prefix}robotiq_85_right_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/visual/right_knuckle.dae" />
+                    <mesh filename="$(find robotiq_description)/meshes/visual/right_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/collision/right_knuckle.stl" />
+                    <mesh filename="$(find robotiq_description)/meshes/collision/right_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -80,12 +82,12 @@
         <link name="${prefix}robotiq_85_left_finger_link">
             <visual>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/visual/left_finger.dae" />
+                    <mesh filename="$(find robotiq_description)/meshes/visual/left_finger.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/collision/left_finger.stl" />
+                    <mesh filename="$(find robotiq_description)/meshes/collision/left_finger.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -98,12 +100,12 @@
         <link name="${prefix}robotiq_85_right_finger_link">
             <visual>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/visual/right_finger.dae" />
+                    <mesh filename="$(find robotiq_description)/meshes/visual/right_finger.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/collision/right_finger.stl" />
+                    <mesh filename="$(find robotiq_description)/meshes/collision/right_finger.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -116,12 +118,12 @@
         <link name="${prefix}robotiq_85_left_inner_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/visual/left_inner_knuckle.dae" />
+                    <mesh filename="$(find robotiq_description)/meshes/visual/left_inner_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/collision/left_inner_knuckle.stl" />
+                    <mesh filename="$(find robotiq_description)/meshes/collision/left_inner_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -134,12 +136,12 @@
         <link name="${prefix}robotiq_85_right_inner_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/visual/right_inner_knuckle.dae" />
+                    <mesh filename="$(find robotiq_description)/meshes/visual/right_inner_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/collision/right_inner_knuckle.stl" />
+                    <mesh filename="$(find robotiq_description)/meshes/collision/right_inner_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -152,12 +154,12 @@
         <link name="${prefix}robotiq_85_left_finger_tip_link">
             <visual>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/visual/left_finger_tip.dae" />
+                    <mesh filename="$(find robotiq_description)/meshes/visual/left_finger_tip.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/collision/left_finger_tip.stl" />
+                    <mesh filename="$(find robotiq_description)/meshes/collision/left_finger_tip.stl" />
                 </geometry>
                 <surface>
                     <friction>
@@ -188,12 +190,12 @@
         <link name="${prefix}robotiq_85_right_finger_tip_link">
             <visual>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/visual/right_finger_tip.dae" />
+                    <mesh filename="$(find robotiq_description)/meshes/visual/right_finger_tip.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="package://robotiq_description/meshes/collision/right_finger_tip.stl" />
+                    <mesh filename="$(find robotiq_description)/meshes/collision/right_finger_tip.stl" />
                 </geometry>
                 <surface>
                     <friction>


### PR DESCRIPTION
To enable the gripper to work with robots like the Kinova Gen3 we need a switch for the user to decide if they want the `ros2_control` xacro included. This is because the Gen3 robot communicates with the gripper directly by itself and the hardware_interface is only needed when simulating.

This PR also updates the mesh loading to use `$(find ` over the ROS specific `package://` so that the mesh files can be found by Gazebo.