### PR TITLE
Catch missed read/write packets

### DIFF
--- a/robotiq_driver/src/hardware_interface.cpp
+++ b/robotiq_driver/src/hardware_interface.cpp
@@ -211,7 +211,7 @@ RobotiqGripperHardwareInterface::on_activate(const rclcpp_lifecycle::State& /*pr
         }
         catch (serial::IOException& e)
         {
-          RCLCPP_ERROR(kLogger, "Check Robotiq Gripper connection and restart drivers.");
+          RCLCPP_ERROR(kLogger, "Check Robotiq Gripper connection and restart drivers. ERROR: %s", e.what());
           command_interface_is_running_.store(false);
         }
       }

--- a/robotiq_driver/src/robotiq_gripper_interface.cpp
+++ b/robotiq_driver/src/robotiq_gripper_interface.cpp
@@ -152,6 +152,11 @@ void RobotiqGripperInterface::setGripperPosition(uint8_t pos)
   {
     // catch connection error and rethrow
     std::cerr << "Failed to set gripper position\n";
+    if (port_.isOpen())
+    {
+      std::cerr << "Error caught while reading or writing to device. Connection is open, continuing to attempt communication with gripper.\n  ERROR: " << e.what();
+      return;
+    }
     throw;
   }
 }

--- a/robotiq_driver/src/robotiq_gripper_interface.cpp
+++ b/robotiq_driver/src/robotiq_gripper_interface.cpp
@@ -320,6 +320,11 @@ void RobotiqGripperInterface::updateStatus()
   catch (const serial::IOException& e)
   {
     std::cerr << "Failed to update gripper status.\n";
+    if (port_.isOpen())
+    {
+      std::cerr << "Error caught while reading or writing to device. Connection is open, continuing to attempt communication with gripper.\n  ERROR: " << e.what();
+      return;
+    }
     throw;
   }
 }


### PR DESCRIPTION
This PR attempts to handle dropped packets between the gripper and computer by not closing communication with it when a read/write packet is missed. The approach is if a read/write exception is thrown but the port is till open tell the user about the event but continue trying to communicate with the device.