### PR TITLE
[WIP] try using libcxx-serial-dev

### DIFF
--- a/robotiq_description/package.xml
+++ b/robotiq_description/package.xml
@@ -9,8 +9,6 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
-  <depend>serial</depend>
-
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 

--- a/robotiq_driver/CMakeLists.txt
+++ b/robotiq_driver/CMakeLists.txt
@@ -12,7 +12,7 @@ find_package(hardware_interface REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_lifecycle REQUIRED)
-find_package(serial REQUIRED)
+find_package(cxx-serial REQUIRED)
 
 set(THIS_PACKAGE_INCLUDE_DEPENDS
   ament_cmake
@@ -20,7 +20,7 @@ set(THIS_PACKAGE_INCLUDE_DEPENDS
   pluginlib
   rclcpp
   rclcpp_lifecycle
-  serial
+  cxx-serial
 )
 
 add_library(
@@ -46,7 +46,7 @@ pluginlib_export_plugin_description_file(hardware_interface hardware_interface_p
 
 add_executable(gripper_interface_test src/gripper_interface_test.cpp)
 target_include_directories(gripper_interface_test PRIVATE include)
-ament_target_dependencies(gripper_interface_test serial)
+ament_target_dependencies(gripper_interface_test cxx-serial)
 target_link_libraries(gripper_interface_test ${PROJECT_NAME})
 
 # INSTALL

--- a/robotiq_driver/include/robotiq_driver/robotiq_gripper_interface.hpp
+++ b/robotiq_driver/include/robotiq_driver/robotiq_gripper_interface.hpp
@@ -31,7 +31,13 @@
 #include <string>
 #include <vector>
 
-#include <serial/serial.h>
+// define this HAVE_STDINT_H to work with headers installed from libcxx-serial-dev
+// Possible bug or missing CMake configuration
+#ifndef HAVE_STDINT_H
+#define HAVE_STDINT_H
+#include <serial.h>
+#undef HAVE_STDINT_H
+#endif
 
 /**
  * @brief This class is responsible for communicating with the gripper via a serial port, and maintaining a record of

--- a/robotiq_driver/package.xml
+++ b/robotiq_driver/package.xml
@@ -13,7 +13,9 @@
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_lifecycle</depend>
-  <depend>serial</depend>
+  <!-- WARNING: cxx-serial is not a valid rosdep key -->
+  <!-- TODO: either release serial or point cxx-serial to libcxx-serial-dev -->
+  <depend>cxx-serial</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/robotiq_driver/src/hardware_interface.cpp
+++ b/robotiq_driver/src/hardware_interface.cpp
@@ -37,7 +37,14 @@
 #include "hardware_interface/actuator_interface.hpp"
 #include "hardware_interface/types/hardware_interface_type_values.hpp"
 #include "rclcpp/rclcpp.hpp"
-#include <serial/serial.h>
+
+// define this HAVE_STDINT_H to work with headers installed from libcxx-serial-dev
+// Possible bug or missing CMake configuration
+#ifndef HAVE_STDINT_H
+#define HAVE_STDINT_H
+#include <serial.h>
+#undef HAVE_STDINT_H
+#endif
 
 constexpr uint8_t kGripperMinPos = 3;
 constexpr uint8_t kGripperMaxPos = 230;


### PR DESCRIPTION
This branch is for testing with `libcxx-serial-dev` See https://github.com/PickNikRobotics/ros2_robotiq_gripper/issues/21

This may be more out of date than the upstream