### PR TITLE
Replace Find with Package in Gripper Xacro

### DIFF
--- a/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
+++ b/robotiq_description/urdf/robotiq_2f_85_gripper.urdf.xacro
@@ -4,7 +4,7 @@
     <xacro:arg name="use_fake_hardware" default="true" />
 
     <!-- Import macros -->
-    <xacro:include filename="$(find robotiq_description)/urdf/robotiq_2f_85_macro.urdf.xacro" />
+    <xacro:include filename="package://robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro" />
 
     <link name="world" />
     <xacro:robotiq_gripper name="RobotiqGripperHardwareInterface" prefix="" parent="world" use_fake_hardware="$(arg use_fake_hardware)">

--- a/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
+++ b/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
@@ -13,7 +13,7 @@
         com_port:=/dev/ttyUSB0">
 
         <!-- ros2 control include -->
-        <xacro:include filename="$(find robotiq_description)/urdf/robotiq_gripper.ros2_control.xacro" />
+        <xacro:include filename="package://robotiq_description/urdf/robotiq_gripper.ros2_control.xacro" />
         <!-- if we are simulating or directly communicating with the gripper we need a ros2 control instance -->
         <xacro:if value="${include_ros2_control}">
             <xacro:robotiq_gripper_ros2_control
@@ -28,12 +28,12 @@
         <link name="${prefix}robotiq_85_base_link">
             <visual>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/visual/robotiq_base.dae" />
+                    <mesh filename="package://robotiq_description/meshes/visual/robotiq_base.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/collision/robotiq_base.stl" />
+                    <mesh filename="package://robotiq_description/meshes/collision/robotiq_base.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -46,12 +46,12 @@
         <link name="${prefix}robotiq_85_left_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/visual/left_knuckle.dae" />
+                    <mesh filename="package://robotiq_description/meshes/visual/left_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/collision/left_knuckle.stl" />
+                    <mesh filename="package://robotiq_description/meshes/collision/left_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -64,12 +64,12 @@
         <link name="${prefix}robotiq_85_right_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/visual/right_knuckle.dae" />
+                    <mesh filename="package://robotiq_description/meshes/visual/right_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/collision/right_knuckle.stl" />
+                    <mesh filename="package://robotiq_description/meshes/collision/right_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -82,12 +82,12 @@
         <link name="${prefix}robotiq_85_left_finger_link">
             <visual>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/visual/left_finger.dae" />
+                    <mesh filename="package://robotiq_description/meshes/visual/left_finger.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/collision/left_finger.stl" />
+                    <mesh filename="package://robotiq_description/meshes/collision/left_finger.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -100,12 +100,12 @@
         <link name="${prefix}robotiq_85_right_finger_link">
             <visual>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/visual/right_finger.dae" />
+                    <mesh filename="package://robotiq_description/meshes/visual/right_finger.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/collision/right_finger.stl" />
+                    <mesh filename="package://robotiq_description/meshes/collision/right_finger.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -118,12 +118,12 @@
         <link name="${prefix}robotiq_85_left_inner_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/visual/left_inner_knuckle.dae" />
+                    <mesh filename="package://robotiq_description/meshes/visual/left_inner_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/collision/left_inner_knuckle.stl" />
+                    <mesh filename="package://robotiq_description/meshes/collision/left_inner_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -136,12 +136,12 @@
         <link name="${prefix}robotiq_85_right_inner_knuckle_link">
             <visual>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/visual/right_inner_knuckle.dae" />
+                    <mesh filename="package://robotiq_description/meshes/visual/right_inner_knuckle.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/collision/right_inner_knuckle.stl" />
+                    <mesh filename="package://robotiq_description/meshes/collision/right_inner_knuckle.stl" />
                 </geometry>
             </collision>
             <inertial>
@@ -154,12 +154,12 @@
         <link name="${prefix}robotiq_85_left_finger_tip_link">
             <visual>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/visual/left_finger_tip.dae" />
+                    <mesh filename="package://robotiq_description/meshes/visual/left_finger_tip.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/collision/left_finger_tip.stl" />
+                    <mesh filename="package://robotiq_description/meshes/collision/left_finger_tip.stl" />
                 </geometry>
                 <surface>
                     <friction>
@@ -190,12 +190,12 @@
         <link name="${prefix}robotiq_85_right_finger_tip_link">
             <visual>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/visual/right_finger_tip.dae" />
+                    <mesh filename="package://robotiq_description/meshes/visual/right_finger_tip.dae" />
                 </geometry>
             </visual>
             <collision>
                 <geometry>
-                    <mesh filename="file://$(find robotiq_description)/meshes/collision/right_finger_tip.stl" />
+                    <mesh filename="package://robotiq_description/meshes/collision/right_finger_tip.stl" />
                 </geometry>
                 <surface>
                     <friction>


### PR DESCRIPTION
Using `$(find)` will replace the lookup with absolute paths, whereas some multi system deployments (e.g. MoveIt Studio) need relative paths to the package and then the file.