### PR TITLE
Allow extending the hardware interface

### DIFF
--- a/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -128,7 +128,7 @@ public:
   ROBOTIQ_DRIVER_PUBLIC
   hardware_interface::return_type write(const rclcpp::Time& time, const rclcpp::Duration& period) override;
 
-private:
+protected:
   // Interface to send binary data to the hardware using the serial port.
   std::unique_ptr<Driver> driver_;
 


### PR DESCRIPTION
By making private member variable protected. This allows external users to extend this hardware interface for different hardware applications or say, the Hand-E gripper.