### PR TITLE
Run coverage CI on Ubuntu 24.04

### DIFF
--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   coverage:
     name: coverage build
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
     env:


### PR DESCRIPTION
Since Rolling is now on Ubuntu 24.04, I believe this is needed to fix the coverage CI build.

The tests will fail until #54 is also merged.