### PR TITLE
Replace gripper_speed_multiplier/gripper_speed_multiplier with gripper_speed/gripper_force. Fix bug 

### DIFF
--- a/robotiq_description/urdf/2f_140.ros2_control.xacro
+++ b/robotiq_description/urdf/2f_140.ros2_control.xacro
@@ -10,7 +10,12 @@
         isaac_joint_states:=/isaac_joint_states
         use_fake_hardware:=false
         fake_sensor_commands:=false
-        com_port:=/dev/ttyUSB0">
+        com_port:=/dev/ttyUSB0
+        gripper_speed:=0.150
+        gripper_force:=235.0
+        gripper_max_speed:=0.150
+        gripper_max_force:=235.0
+        gripper_closed_position:=0.695">
 
         <ros2_control name="${name}" type="system">
             <!-- Plugins -->
@@ -30,10 +35,12 @@
                 </xacro:if>
                 <xacro:unless value="${use_fake_hardware or sim_ignition or sim_isaac}">
                     <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
-                    <param name="gripper_closed_position">0.695</param>
+                    <param name="gripper_closed_position">${gripper_closed_position}</param>
                     <param name="COM_port">${com_port}</param>
-                    <param name="gripper_speed_multiplier">1.0</param>
-                    <param name="gripper_force_multiplier">0.5</param>
+                    <param name="gripper_speed">${gripper_speed}</param>
+                    <param name="gripper_force">${gripper_force}</param>
+                    <param name="gripper_max_speed">${gripper_max_speed}</param>
+                    <param name="gripper_max_force">${gripper_max_force}</param>
                 </xacro:unless>
             </hardware>
 
@@ -42,7 +49,7 @@
             <joint name="${prefix}finger_joint">
                 <command_interface name="position" />
                 <state_interface name="position">
-                    <param name="initial_value">0.695</param>
+                    <param name="initial_value">${gripper_closed_position}</param>
                 </state_interface>
                 <state_interface name="velocity"/>
             </joint>

--- a/robotiq_description/urdf/2f_85.ros2_control.xacro
+++ b/robotiq_description/urdf/2f_85.ros2_control.xacro
@@ -10,7 +10,12 @@
         isaac_joint_states:=/isaac_joint_states
         use_fake_hardware:=false
         fake_sensor_commands:=false
-        com_port:=/dev/ttyUSB0">
+        com_port:=/dev/ttyUSB0
+        gripper_speed:=0.150
+        gripper_force:=235.0
+        gripper_max_speed:=0.150
+        gripper_max_force:=235.0
+        gripper_closed_position:=0.7929">
 
         <ros2_control name="${name}" type="system">
             <!-- Plugins -->
@@ -35,10 +40,12 @@
                 </xacro:if>
                 <xacro:unless value="${use_fake_hardware or sim_ignition or sim_isaac}">
                     <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
-                    <param name="gripper_closed_position">0.7929</param>
+                    <param name="gripper_closed_position">${gripper_closed_position}</param>
                     <param name="COM_port">${com_port}</param>
-                    <param name="gripper_speed_multiplier">1.0</param>
-                    <param name="gripper_force_multiplier">0.5</param>
+                    <param name="gripper_speed">${gripper_speed}</param>
+                    <param name="gripper_force">${gripper_force}</param>
+                    <param name="gripper_max_speed">${gripper_max_speed}</param>
+                    <param name="gripper_max_force">${gripper_max_force}</param>
                 </xacro:unless>
             </hardware>
 
@@ -47,7 +54,7 @@
             <joint name="${prefix}robotiq_85_left_knuckle_joint">
                 <command_interface name="position" />
                 <state_interface name="position">
-                    <param name="initial_value">0.7929</param>
+                    <param name="initial_value">${gripper_closed_position}</param>
                 </state_interface>
                 <state_interface name="velocity"/>
             </joint>

--- a/robotiq_description/urdf/robotiq_2f_140_macro.urdf.xacro
+++ b/robotiq_description/urdf/robotiq_2f_140_macro.urdf.xacro
@@ -12,7 +12,12 @@
         use_fake_hardware:=false
         fake_sensor_commands:=false
         include_ros2_control:=true
-        com_port:=/dev/ttyUSB0">
+        com_port:=/dev/ttyUSB0
+        gripper_speed:=0.150
+        gripper_force:=235.0
+        gripper_max_speed:=0.150
+        gripper_max_force:=235.0
+        gripper_closed_position:=0.695">
 
         <!-- ros2 control include -->
         <xacro:include filename="$(find robotiq_description)/urdf/2f_140.ros2_control.xacro" />
@@ -26,7 +31,12 @@
                 isaac_joint_states="${isaac_joint_states}"
                 use_fake_hardware="${use_fake_hardware}"
                 fake_sensor_commands="${fake_sensor_commands}"
-                com_port="${com_port}"/>
+                com_port="${com_port}"
+                gripper_speed="${gripper_speed}"
+                gripper_force="${gripper_force}"
+                gripper_max_speed="${gripper_max_speed}"
+                gripper_max_force="${gripper_max_force}"
+                gripper_closed_position="${gripper_closed_position}"/>
         </xacro:if>
 
         <!-- this is a temporary link to rotate the 2f-140 gripper to match the 2f-85 -->

--- a/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
+++ b/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
@@ -12,7 +12,13 @@
         use_fake_hardware:=false
         fake_sensor_commands:=false
         include_ros2_control:=true
-        com_port:=/dev/ttyUSB0">
+        com_port:=/dev/ttyUSB0
+        gripper_speed:=0.150
+        gripper_force:=235.0
+        gripper_max_speed:=0.150
+        gripper_max_force:=235.0
+        gripper_closed_position:=0.7929">
+
 
         <!-- ros2 control include -->
         <xacro:include filename="$(find robotiq_description)/urdf/2f_85.ros2_control.xacro" />
@@ -26,7 +32,12 @@
                 isaac_joint_states="${isaac_joint_states}"
                 use_fake_hardware="${use_fake_hardware}"
                 fake_sensor_commands="${fake_sensor_commands}"
-                com_port="${com_port}"/>
+                com_port="${com_port}"
+                gripper_speed="${gripper_speed}"
+                gripper_force="${gripper_force}"
+                gripper_max_speed="${gripper_max_speed}"
+                gripper_max_force="${gripper_max_force}"
+                gripper_closed_position="${gripper_closed_position}"/>
         </xacro:if>
 
         <link name="${prefix}robotiq_85_base_link">

--- a/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -141,6 +141,8 @@ protected:
   void background_task();
 
   double gripper_closed_pos_ = 0.0;
+  double gripper_max_speed_ = 0.0;
+  double gripper_max_force_ = 0.0;
 
   static constexpr double NO_NEW_CMD_ = std::numeric_limits<double>::quiet_NaN();
 

--- a/robotiq_driver/src/default_driver_factory.cpp
+++ b/robotiq_driver/src/default_driver_factory.cpp
@@ -43,10 +43,10 @@ const auto kLogger = rclcpp::get_logger("DefaultDriverFactory");
 constexpr auto kSlaveAddressParamName = "slave_address";
 constexpr uint8_t kSlaveAddressParamDefault = 0x09;
 
-constexpr auto kGripperSpeedMultiplierParamName = "gripper_speed_multiplier";
+constexpr auto kGripperSpeedMultiplierParamName = "gripper_speed";
 constexpr double kGripperSpeedMultiplierParamDefault = 1.0;
 
-constexpr auto kGripperForceMultiplierParamName = "gripper_force_multiplier";
+constexpr auto kGripperForceMultiplierParamName = "gripper_force";
 constexpr double kGripperForceMultiplierParamDefault = 1.0;
 
 constexpr auto kUseDummyParamName = "use_dummy";

--- a/robotiq_driver/tests/test_default_driver_factory.cpp
+++ b/robotiq_driver/tests/test_default_driver_factory.cpp
@@ -86,8 +86,8 @@ TEST(TestDefaultDriverFactory, create_with_given_parameters)
   hardware_interface::HardwareInfo info;
 
   info.hardware_parameters.emplace("slave_address", "1");
-  info.hardware_parameters.emplace("gripper_speed_multiplier", "0.5");
-  info.hardware_parameters.emplace("gripper_force_multiplier", "0.5");
+  info.hardware_parameters.emplace("gripper_speed", "0.5");
+  info.hardware_parameters.emplace("gripper_force", "0.5");
 
   auto driver = std::make_unique<MockDriver>();
 

--- a/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
+++ b/robotiq_driver/tests/test_robotiq_gripper_hardware_interface.cpp
@@ -59,8 +59,8 @@ TEST(TestRobotiqGripperHardwareInterface, load_urdf)
          <ros2_control name="robotiq_driver_ros2_control" type="system">
            <hardware>
              <plugin>robotiq_driver/RobotiqGripperHardwareInterface</plugin>
-             <param name="gripper_speed_multiplier">1.0</param>
-             <param name="gripper_force_multiplier">0.5</param>
+             <param name="gripper_speed">1.0</param>
+             <param name="gripper_force">0.5</param>
              <param name="COM_port">/dev/ttyUSB0</param>
              <param name="gripper_closed_position">0.7929</param>
            </hardware>


### PR DESCRIPTION

1. replace gripper_speed_multiplier/gripper_force_multiplier with gripper_speed/gripper_force
2. fix bug of not reading gripper_speed/gripper_force(previously gripper_speed_multiplier/gripper_force_multiplier)
3. expose max_speed and max_force parameters to xacro

Fixes bugs mention here: https://github.com/PickNikRobotics/ros2_robotiq_gripper/issues/57