### PR TITLE
Fix compilation error by adding missing <algorithm> include for std::clamp

### DIFF
--- a/robotiq_driver/src/default_driver_factory.cpp
+++ b/robotiq_driver/src/default_driver_factory.cpp
@@ -27,6 +27,7 @@
 // POSSIBILITY OF SUCH DAMAGE.
 
 #include <cmath>
+#include <algorithm>
 
 #include <robotiq_driver/default_driver_factory.hpp>
 #include <robotiq_driver/default_driver.hpp>


### PR DESCRIPTION
Fix: https://github.com/PickNikRobotics/ros2_robotiq_gripper/issues/80

This PR fixes a compilation error in default_driver_factory.cpp where the use of std::clamp was causing a failure due to the missing <algorithm> header. Adding the appropriate include resolves the error:

```
error: no member named 'clamp' in namespace 'std'
```

I tested the change locally in my build environment (using clang with the Conda-provided GCC toolchain) and verified that the error no longer occurs. This change should improve compatibility when building with >=C++17 standard libraries.