### PR TITLE
Fix deprecated hardware_interface API

### DIFF
--- a/robotiq_controllers/src/robotiq_activation_controller.cpp
+++ b/robotiq_controllers/src/robotiq_activation_controller.cpp
@@ -108,11 +108,11 @@ bool RobotiqActivationController::reactivateGripper(std_srvs::srv::Trigger::Requ
   command_interfaces_[REACTIVATE_GRIPPER_RESPONSE].set_value(ASYNC_WAITING);
   command_interfaces_[REACTIVATE_GRIPPER_CMD].set_value(1.0);
 
-  while (command_interfaces_[REACTIVATE_GRIPPER_RESPONSE].get_value() == ASYNC_WAITING)
+  while (command_interfaces_[REACTIVATE_GRIPPER_RESPONSE].get_optional().value() == ASYNC_WAITING)
   {
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
   }
-  resp->success = command_interfaces_[REACTIVATE_GRIPPER_RESPONSE].get_value();
+  resp->success = command_interfaces_[REACTIVATE_GRIPPER_RESPONSE].get_optional().value();
 
   return resp->success;
 }

--- a/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
+++ b/robotiq_driver/include/robotiq_driver/hardware_interface.hpp
@@ -77,7 +77,7 @@ public:
    * parsed or CallbackReturn::ERROR if any error happens or data are missing.
    */
   ROBOTIQ_DRIVER_PUBLIC
-  CallbackReturn on_init(const hardware_interface::HardwareInfo& info) override;
+  CallbackReturn on_init(const hardware_interface::HardwareComponentInterfaceParams& params) override;
 
   /**
    * Connect to the hardware.

--- a/robotiq_driver/src/hardware_interface.cpp
+++ b/robotiq_driver/src/hardware_interface.cpp
@@ -72,11 +72,11 @@ RobotiqGripperHardwareInterface::RobotiqGripperHardwareInterface(std::unique_ptr
 {
 }
 
-hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_init(const hardware_interface::HardwareInfo& info)
+hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_init(const hardware_interface::HardwareComponentInterfaceParams& params)
 {
   RCLCPP_DEBUG(kLogger, "on_init");
 
-  if (hardware_interface::SystemInterface::on_init(info) != CallbackReturn::SUCCESS)
+  if (hardware_interface::SystemInterface::on_init(params) != CallbackReturn::SUCCESS)
   {
     return CallbackReturn::ERROR;
   }

--- a/robotiq_driver/src/hardware_interface.cpp
+++ b/robotiq_driver/src/hardware_interface.cpp
@@ -72,7 +72,8 @@ RobotiqGripperHardwareInterface::RobotiqGripperHardwareInterface(std::unique_ptr
 {
 }
 
-hardware_interface::CallbackReturn RobotiqGripperHardwareInterface::on_init(const hardware_interface::HardwareComponentInterfaceParams& params)
+hardware_interface::CallbackReturn
+RobotiqGripperHardwareInterface::on_init(const hardware_interface::HardwareComponentInterfaceParams& params)
 {
   RCLCPP_DEBUG(kLogger, "on_init");
 


### PR DESCRIPTION
See https://github.com/ros-controls/ros2_control/pull/2323
needed for https://github.com/ros-controls/ros2_control/pull/2589

Please release it to kilted and rolling, thanks :)
Note: This API is not available on humble.