### PR TITLE
Update gripper_controllers to parallel_gripper_controller

### DIFF
--- a/robotiq_description/config/robotiq_controllers.yaml
+++ b/robotiq_description/config/robotiq_controllers.yaml
@@ -3,17 +3,29 @@ controller_manager:
     update_rate: 500  # Hz
     joint_state_broadcaster:
       type: joint_state_broadcaster/JointStateBroadcaster
+    # Jazzy and newer: parallel_gripper_action_controller replaces gripper_controllers package
     robotiq_gripper_controller:
-      type: position_controllers/GripperActionController
+      type: parallel_gripper_action_controller/GripperActionController
     robotiq_activation_controller:
       type: robotiq_controllers/RobotiqActivationController
 
 robotiq_gripper_controller:
   ros__parameters:
-    default: true
     joint: robotiq_85_left_knuckle_joint
-    use_effort_interface: true
-    use_speed_interface: true
+
+    # Enable effort control (replacement for use_effort_interface)
+    max_effort_interface: "robotiq_85_left_knuckle_joint/effort"
+    max_effort: 50.0   # TODO tune
+
+    # Enable velocity/speed control (replacement for use_speed_interface)
+    max_velocity_interface: "robotiq_85_left_knuckle_joint/velocity"
+    max_velocity: 0.5    # TODO tune
+
+    # Optional (recommended)
+    state_interfaces: ["position", "velocity"]
+    allow_stalling: true
+    stall_timeout: 0.05
+    goal_tolerance: 0.02
 
 robotiq_activation_controller:
   ros__parameters:

--- a/robotiq_description/package.xml
+++ b/robotiq_description/package.xml
@@ -22,8 +22,8 @@
   <exec_depend>ros2_control</exec_depend>
   <exec_depend>ros2_controllers</exec_depend>
 
-  <exec_depend>gripper_controllers</exec_depend>
   <exec_depend>joint_state_broadcaster</exec_depend>
+  <exec_depend>parallel_gripper_controller</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>


### PR DESCRIPTION
Replaced 'gripper_controllers' package that was removed in Rolling and Kilted with 'parallel_gripper_controller'.