### PR TITLE
Fix gripper command ordering: send position last

### DIFF
--- a/robotiq_driver/src/hardware_interface.cpp
+++ b/robotiq_driver/src/hardware_interface.cpp
@@ -325,9 +325,9 @@ void RobotiqGripperHardwareInterface::background_task()
       }
 
       // Write the latest command to the gripper.
-      this->driver_->set_gripper_position(write_command_.load());
       this->driver_->set_speed(write_speed_.load());
       this->driver_->set_force(write_force_.load());
+      this->driver_->set_gripper_position(write_command_.load());
 
       // Read the state of the gripper.
       gripper_current_state_.store(this->driver_->get_gripper_position());


### PR DESCRIPTION
Before this change the position command was sent first, which started the motion using the previously configured velocity and effort. If a high velocity/effort had been sent earlier, the gripper would begin moving quickly even when the new action command specified a low velocity. This caused an undesired initial fast movement.