### PR TITLE
Export gazebo model path in package.xml

### DIFF
--- a/robotiq_description/package.xml
+++ b/robotiq_description/package.xml
@@ -30,5 +30,6 @@
 
   <export>
     <build_type>ament_cmake</build_type>
+    <gazebo_ros gazebo_model_path="${prefix}/../"/>
   </export>
 </package>


### PR DESCRIPTION
Export the `gazebo_model_path` in `package.xml` so that including this packages do not have to set the path manually when using gazebo.

To be honest i am not sure if this is the way it's done, i search a bit but could not really find what the standard/preferred way here is. Would also be happy if someone can point me to the docs on this:) If the standard way is that the path is always set manually when using gazebo then ignore this pr and my apology.