### PR TITLE
Update knuckle vel from 0.5 to 100

### DIFF
--- a/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
+++ b/robotiq_description/urdf/robotiq_2f_85_macro.urdf.xacro
@@ -249,7 +249,7 @@
             <child link="${prefix}robotiq_85_left_knuckle_link" />
             <axis xyz="0 -1 0" />
             <origin xyz="0.03060114 0.0 0.05490452" rpy="0 0 0" />
-            <limit lower="0.0" upper="0.8" velocity="0.5" effort="50" />
+            <limit lower="0.0" upper="0.8" velocity="100" effort="50" />
         </joint>
 
         <joint name="${prefix}robotiq_85_right_knuckle_joint" type="revolute">
@@ -257,7 +257,7 @@
             <child link="${prefix}robotiq_85_right_knuckle_link" />
             <axis xyz="0 -1 0" />
             <origin xyz="-0.03060114 0.0 0.05490452" rpy="0 0 0" />
-            <limit lower="-0.8" upper="0.0" velocity="0.5" effort="50" />
+            <limit lower="-0.8" upper="0.0" velocity="100" effort="50" />
             <mimic joint="${prefix}robotiq_85_left_knuckle_joint" multiplier="-1" />
         </joint>
 


### PR DESCRIPTION
When running the robotiq_driver on the hardware I got an interrupted motion, like start and stop during the opening and closing, both using the Parallel Gripper Action Controller and the Trajectory Controller.
I solved that issue by just increasing the hard coded velocity limit in the robotiq xacro.

There might be better solutions out there.
Making the pull request just to flag the issue and show my current solution.