### PR TITLE
Update checkout action version from v4 to v6

### DIFF
--- a/.github/workflows/ci-ros-lint.yml
+++ b/.github/workflows/ci-ros-lint.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         linter: [copyright, lint_cmake]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ros-tooling/setup-ros@v0.7
       - uses: ros-tooling/action-ros-lint@v0.1
         with:
@@ -29,7 +29,7 @@ jobs:
       matrix:
         linter: [cpplint]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ros-tooling/setup-ros@v0.7
       - uses: ros-tooling/action-ros-lint@v0.1
         with:


### PR DESCRIPTION
fix node.js deprecation