### PR TITLE
ci: mark Rolling-on-Noble-apt jobs non-blocking during base-OS transition

### DIFF
--- a/.github/workflows/ci-coverage-build.yml
+++ b/.github/workflows/ci-coverage-build.yml
@@ -11,6 +11,20 @@ jobs:
   coverage:
     name: coverage build
     runs-on: ubuntu-24.04
+    # Non-blocking while Rolling completes its Noble → Resolute base-OS transition.
+    #
+    # Observed 2026-07 on Ubuntu 24.04 (noble) runners: rosdep can't resolve
+    # Rolling's ros2_control dep chain for noble, so `apt-get install` skips
+    # runtime deps and the subsequent `colcon build` fails at
+    # `find_package(controller_interface REQUIRED)`. Upstream root cause: Rolling
+    # has migrated to Resolute and its dep chain no longer resolves against
+    # noble apt. Not fixable at the workflow level here (unlike industrial_ci
+    # jobs, this one runs ros-tooling/action-ros-ci directly on the runner).
+    #
+    # Revisit when either (a) `ros-tooling/action-ros-ci` releases a version that
+    # switches its runner base to Resolute, or (b) we wrap this workflow in
+    # `industrial_ci` with `OS_CODE_NAME: resolute` (matching moveit2's approach).
+    continue-on-error: true
     strategy:
       fail-fast: false
     env:

--- a/.github/workflows/reusable-industrial-ci-with-cache.yml
+++ b/.github/workflows/reusable-industrial-ci-with-cache.yml
@@ -45,11 +45,17 @@ on:
         default: ".work"
         required: false
         type: string
+      continue_on_error:
+        description: 'Whether job failure should be treated as workflow success. Useful for tracking-only jobs (e.g. Rolling on main apt during a base-OS transition).'
+        default: false
+        required: false
+        type: boolean
 
 jobs:
   reusable_industrial_ci_with_cache:
     name: ${{ inputs.ros_distro }} ${{ inputs.ros_repo }} ${{ inputs.os_code_name }}
     runs-on: ubuntu-22.04
+    continue-on-error: ${{ inputs.continue_on_error }}
     env:
       CCACHE_DIR: ${{ github.workspace }}/${{ inputs.ccache_dir }}
       BASEDIR: ${{ github.workspace }}/${{ inputs.basedir }}

--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -18,14 +18,14 @@ on:
 
 jobs:
   binary:
-    # Non-blocking while Rolling main apt catches up to the Noble → Resolute
-    # base-OS transition. The rolling-binary-build-testing companion currently
-    # passes (Rolling-on-Resolute packages live in ros2-testing apt); this job
-    # will turn green on its own once those packages promote to main apt.
-    continue-on-error: true
     uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
     with:
       ros_distro: rolling
       ros_repo: main
       upstream_workspace: ros2_robotiq_gripper-not-released.rolling.repos
       ref_for_scheduled_build: main
+      # Non-blocking while Rolling main apt catches up to the Noble → Resolute
+      # base-OS transition. The rolling-binary-build-testing companion currently
+      # passes (Rolling-on-Resolute packages live in ros2-testing apt); this job
+      # will turn green on its own once those packages promote to main apt.
+      continue_on_error: true

--- a/.github/workflows/rolling-binary-build-main.yml
+++ b/.github/workflows/rolling-binary-build-main.yml
@@ -18,6 +18,11 @@ on:
 
 jobs:
   binary:
+    # Non-blocking while Rolling main apt catches up to the Noble → Resolute
+    # base-OS transition. The rolling-binary-build-testing companion currently
+    # passes (Rolling-on-Resolute packages live in ros2-testing apt); this job
+    # will turn green on its own once those packages promote to main apt.
+    continue-on-error: true
     uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
     with:
       ros_distro: rolling

--- a/.github/workflows/rolling-semi-binary-build-main.yml
+++ b/.github/workflows/rolling-semi-binary-build-main.yml
@@ -17,14 +17,14 @@ on:
 
 jobs:
   semi_binary:
-    # Non-blocking while Rolling main apt catches up to the Noble → Resolute
-    # base-OS transition. The rolling-semi-binary-build-testing companion
-    # currently passes (Rolling-on-Resolute packages live in ros2-testing apt);
-    # this job will turn green on its own once those packages promote to main.
-    continue-on-error: true
     uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
     with:
       ros_distro: rolling
       ros_repo: main
       upstream_workspace: ros2_robotiq_gripper.rolling.repos
       ref_for_scheduled_build: main
+      # Non-blocking while Rolling main apt catches up to the Noble → Resolute
+      # base-OS transition. The rolling-semi-binary-build-testing companion
+      # currently passes (Rolling-on-Resolute packages live in ros2-testing apt);
+      # this job will turn green on its own once those packages promote to main.
+      continue_on_error: true

--- a/.github/workflows/rolling-semi-binary-build-main.yml
+++ b/.github/workflows/rolling-semi-binary-build-main.yml
@@ -17,6 +17,11 @@ on:
 
 jobs:
   semi_binary:
+    # Non-blocking while Rolling main apt catches up to the Noble → Resolute
+    # base-OS transition. The rolling-semi-binary-build-testing companion
+    # currently passes (Rolling-on-Resolute packages live in ros2-testing apt);
+    # this job will turn green on its own once those packages promote to main.
+    continue-on-error: true
     uses: ./.github/workflows/reusable-industrial-ci-with-cache.yml
     with:
       ros_distro: rolling


### PR DESCRIPTION
Rolling has migrated to Ubuntu Resolute but its dep chain no longer resolves cleanly against Noble apt. Three workflows are affected:

- ci-coverage-build: fails at `find_package(controller_interface REQUIRED)` because `ros2_control`'s runtime deps aren't apt-installable on noble.
- rolling-binary-build-main and rolling-semi-binary-build-main: fail because ros_repo=main hasn't promoted the Resolute packages yet.

The corresponding `-testing` variants (rolling-binary-build-testing, rolling-semi-binary-build-testing) pass — Rolling-on-Resolute packages live in ros2-testing apt. Adding continue-on-error preserves the informational signal on the -main variants without gating merges. Coverage build gets the same treatment plus a comment recording the specific failure signature for future maintainers.

Same shape as picknik_controllers#37.