### PR TITLE
robotiq_driver: set CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE

### DIFF
--- a/robotiq_driver/CMakeLists.txt
+++ b/robotiq_driver/CMakeLists.txt
@@ -6,6 +6,12 @@ project(robotiq_driver LANGUAGES CXX)
 # This module provides installation directories as per the GNU coding standards.
 include(GNUInstallDirs)
 
+# Add directories of linked libraries (including transitive ones) to install
+# RPATH. Without this, executables that link to robotiq_driver get only the
+# workspace install dir in their RPATH, and the dynamic loader fails to find
+# transitively-needed libs like libhardware_interface.so from /opt/ros/$distro.
+set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
+
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic)
 endif()


### PR DESCRIPTION
## Why

Executables built downstream of `robotiq_driver` fail at runtime with dynamic-loader errors when they need transitively-linked libraries — e.g. tests that link `robotiq_driver` (which itself links `hardware_interface`) can't find `libhardware_interface.so` at runtime because it lives in `/opt/ros/$distro/lib`, and that directory isn't in the test binary's RPATH.

The default CMake install policy only puts the workspace's own install prefix into consumer RPATHs. Transitive dependencies whose `.so` files live outside the workspace tree are unresolvable unless the loader path is manually augmented (via `LD_LIBRARY_PATH` etc.) or CMake is told to include linked-library directories in the install RPATH.

## How

Set `CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE` at the top of the `robotiq_driver` CMake package. CMake then augments every install RPATH with the parent directories of each linked library, so `/opt/ros/$distro/lib` ends up in the RPATH of any binary consuming `robotiq_driver`, and the loader finds `libhardware_interface.so` without extra environment gymnastics.

Additive, no behavior change on machines where the loader could already find the library via `LD_LIBRARY_PATH` or the system linker cache. Just closes the gap for environments (test containers, packaged installs) where those fallbacks aren't set up.

## Background

Extracted from [#121](https://github.com/PickNikRobotics/ros2_robotiq_gripper/pull/121) as a standalone fix. That PR bundled this with Rolling-on-Resolute CI workarounds that have since been superseded by [#129](https://github.com/PickNikRobotics/ros2_robotiq_gripper/pull/129) (`continue-on-error` on the affected workflows). The RPATH fix is orthogonal to the ecosystem transition and worth landing on its own.
