### PR TITLE
Update README.md directing users to official drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ros2_robotiq_gripper
 
+This repository is no longer maintained - we recommend migrating to the official Robotiq ROS 2 drivers using their migration instructions [here](https://github.com/robotiq/ros).
+
+## Historical context
+
 This repository contains the ROS 2 driver, controller and description packages for working with a Robotiq Gripper.
 
 The goal is to support multiple Robotiq Grippers.


### PR DESCRIPTION
Robotiq has released officially supported ROS 2 drivers for their 2F-85 and 2F-140 grippers and TSF-85 tactile sensor, announced [here](https://blog.robotiq.com/robotiq-releases-ros-2-packages-for-adaptive-grippers) and based on this repository.

This is great news so that the grippers gets official support and more advanced driver features for dextrous action transformer applications.